### PR TITLE
Improved icon sizes

### DIFF
--- a/lib/toolbar-view.coffee
+++ b/lib/toolbar-view.coffee
@@ -35,10 +35,8 @@ class ToolbarView extends View
     @detach()
 
   updateSize: (size) ->
-    @removeClass 'icons16'
-
-    if size == '16px'
-      @addClass 'icons16'
+    @removeClass 'icons16px icons24px icons32px'
+    @addClass 'icons' + size
 
   hide: ->
     @detach()

--- a/lib/toolbar.coffee
+++ b/lib/toolbar.coffee
@@ -32,7 +32,7 @@ module.exports =
     iconSize:
       type: 'string'
       default: '24px'
-      enum: ['16px', '24px']
+      enum: ['16px', '24px', '32px']
 
   prependButton: (icon, callback, tooltip=null, iconset=null) ->
     button = new ToolbarButtonView icon, callback, tooltip, iconset

--- a/styles/toolbar.less
+++ b/styles/toolbar.less
@@ -2,94 +2,109 @@
 @import "../iconsets/ionicons/ionicons";
 @import "../iconsets/font-awesome/font-awesome";
 
-@size: 48px;
-
 #toolbar {
   background-color: @app-background-color;
   color: @text-color;
   text-align: center;
-  line-height: @size;
 
   &.top {
-    width: 100%;
-    height: @size + 1;
-    border-bottom: 1px solid @base-border-color;
-  }
 
+  }
   &.right {
-    width: @size + 1;
-    height: 100%;
-    border-left: 1px solid @base-border-color;
-  }
-
-  &.bottom {
-    width: 100% + 1;
-    height: @size;
-    border-top: 1px solid @base-border-color;
-  }
-
-  &.left {
-    width: @size + 1;
-    height: 100%;
     border-right: 1px solid @base-border-color;
+    border-left: 1px solid @base-border-color;
+    margin-left: -1px;
+  }
+  &.bottom {
+
+  }
+  &.left {
+    margin-top: @ui-tab-height + 0.75em;
   }
 
   &.horizontal {
-    .icon {
-      width: @size;
-      height: 100%;
-    }
-
     .spacer {
       height: 100%;
       border-right: 1px solid @overlay-border-color;
     }
   }
-
   &.vertical {
-    .icon {
-      width: 100%;
-      height: @size;
-    }
-
     .spacer {
       width: 100%;
       border-bottom: 1px solid @overlay-border-color;
     }
   }
 
-  &.icons16 {
-    .icon:before {
-      font-size: 16px !important;
-    }
-  }
-
-  > div {
-    float: left;
-  }
-
   .icon {
+    float: left;
     cursor: pointer;
-
     &:hover {
       color: @text-color-highlight;
     }
-
     &:before {
-      font-size: 24px;
-      margin-right: 0px;
-      line-height: @size;
+      margin-right: 0;
       display: inline;
     }
-
     &.disabled {
       color: @text-color-subtle;
     }
   }
 
   .spacer {
+    float: left;
     &:first-child {
       display: none;
+    }
+  }
+
+  &.icons16px {
+    .size(16px*2);
+  }
+  &.icons24px {
+    .size(24px*2);
+  }
+  &.icons32px {
+    .size(32px*2);
+  }
+
+  .size(@size) {
+    line-height: @size;
+
+    &.top {
+      width: 100%;
+      height: @size + 1;
+    }
+    &.right {
+      width: @size + 1;
+      height: 100%;
+    }
+    &.bottom {
+      width: 100%;
+      height: @size + 1;
+    }
+    &.left {
+      width: @size + 1;
+      height: 100%;
+    }
+
+    &.horizontal {
+      .icon {
+        width: @size;
+        height: 100%;
+      }
+    }
+    &.vertical {
+      .icon {
+        width: 100%;
+        height: @size;
+      }
+    }
+
+    .icon {
+      &:before {
+        font-size: @size / 2;
+        line-height: @size;
+      }
     }
   }
 }


### PR DESCRIPTION
I never liked how the toolbar size was fixed, when the icons size could be changed. This PR addresses that issue and adds a new size, together with some clean up.

This PR contains:
* [x] A new size, 32px.
* [x] Toolbar now sizes with the icons.
* [x] Less code cleaned up. Mixin function used for all sizing code.
* [x] Improvements to the toolbar borders in all positions.

Might fix https://github.com/suda/toolbar/issues/2 & https://github.com/suda/toolbar/issues/4

Great package!