### PR TITLE
atom.workspaceView is deprecated. Fixes #8 and fixes #18

### DIFF
--- a/lib/toolbar-button-view.coffee
+++ b/lib/toolbar-button-view.coffee
@@ -23,7 +23,7 @@ class ToolbarButtonView extends View
     @on 'click', =>
       if !@hasClass('disabled')
         if typeof(callback) == 'string'
-          atom.workspaceView.trigger callback
+          atom.commands.dispatch atom.views.getView(atom.workspace), callback
         else
           callback()
 


### PR DESCRIPTION
`atom.workspaceView` is deprecated. 

Fixes #8 and fixes #18.