### PR TITLE
Toolbar theme. Closes #19

### DIFF
--- a/lib/toolbar-button-view.coffee
+++ b/lib/toolbar-button-view.coffee
@@ -1,17 +1,14 @@
 {CompositeDisposable} = require 'atom'
 {View} = require 'atom-space-pen-views'
 
-module.exports =
-class ToolbarButtonView extends View
+module.exports = class ToolbarButtonView extends View
   @content: ->
-    @div class: 'icon'
+    @div class: 'tool-bar-btn'
 
   initialize: (icon, callback, tooltip = null, iconset = null) ->
     @subscriptions = new CompositeDisposable
 
-    iconClass = if !iconset then 'icon-' + icon else iconset + '-' + icon
-
-    @addClass 'icon ' + iconClass
+    @addClass if !iconset then 'icon-' + icon else iconset + '-' + icon
 
     if tooltip
       @prop 'title', tooltip

--- a/lib/toolbar-view.coffee
+++ b/lib/toolbar-view.coffee
@@ -1,14 +1,12 @@
 {CompositeDisposable} = require 'atom'
 {View} = require 'atom-space-pen-views'
 
-module.exports =
-class ToolbarView extends View
+module.exports = class ToolbarView extends View
   @content: ->
-    @div id: 'toolbar'
+    @div class: 'tool-bar'
 
   initialize: (serializeState) ->
     @subscriptions = new CompositeDisposable
-
     @subscriptions.add atom.commands.add 'atom-workspace', 'toolbar:toggle', => @toggle()
 
     atom.config.observe 'toolbar.iconSize', (newValue) =>
@@ -31,30 +29,32 @@ class ToolbarView extends View
     @panel.destroy() if @panel?
 
   updateSize: (size) ->
-    @removeClass 'icons16px icons24px icons32px'
-    @addClass 'icons' + size
+    @removeClass 'tool-bar-16px tool-bar-24px tool-bar-32px'
+    @addClass 'tool-bar-' + size
+
+  updatePosition: (position) ->
+    @removeClass 'tool-bar-top tool-bar-right tool-bar-bottom tool-bar-left tool-bar-horizontal tool-bar-vertical'
+
+    switch position
+      when 'Top' then @panel = atom.workspace.addTopPanel { item: @ }
+      when 'Right' then @panel = atom.workspace.addRightPanel { item: @ }
+      when 'Bottom' then @panel = atom.workspace.addBottomPanel { item: @ }
+      when 'Left' then @panel = atom.workspace.addLeftPanel { item: @, priority: 50 }
+    @addClass 'tool-bar-' + position.toLowerCase()
+
+    if position is 'Top' or position is 'Bottom'
+      @addClass 'tool-bar-horizontal'
+    else
+      @addClass 'tool-bar-vertical'
 
   hide: ->
     @detach() if @panel?
     @panel.destroy() if @panel?
 
   show: ->
-    @removeClass()
     @hide()
-    position = atom.config.get 'toolbar.position'
-    switch position
-      when 'Top' then @panel = atom.workspace.addTopPanel { item: @ }
-      when 'Right' then @panel = atom.workspace.addRightPanel { item: @ }
-      when 'Bottom' then @panel = atom.workspace.addBottomPanel { item: @ }
-      when 'Left' then @panel = atom.workspace.addLeftPanel { item: @, priority: 50 }
-
-    @addClass position.toLowerCase()
-    if (position == 'Top') || (position == 'Bottom')
-      @addClass 'horizontal'
-    else
-      @addClass 'vertical'
-
-    @updateSize atom.config.get('toolbar.iconSize')
+    @updatePosition atom.config.get 'toolbar.position'
+    @updateSize atom.config.get 'toolbar.iconSize'
 
   toggle: ->
     if @hasParent()

--- a/lib/toolbar.coffee
+++ b/lib/toolbar.coffee
@@ -34,22 +34,22 @@ module.exports =
       default: '24px'
       enum: ['16px', '24px', '32px']
 
-  prependButton: (icon, callback, tooltip=null, iconset=null) ->
+  prependButton: (icon, callback, tooltip = null, iconset = null) ->
     button = new ToolbarButtonView icon, callback, tooltip, iconset
     @toolbarView.prepend button
     button
 
   prependSpacer: (view) ->
-    spacer = $$ -> @div class: 'spacer'
+    spacer = $$ -> @div class: 'tool-bar-spacer'
     @toolbarView.prepend spacer
     spacer
 
-  appendButton: (icon, callback, tooltip=null, iconset=null) ->
+  appendButton: (icon, callback, tooltip = null, iconset = null) ->
     button = new ToolbarButtonView icon, callback, tooltip, iconset
     @toolbarView.append button
     button
 
   appendSpacer: (view) ->
-    spacer = $$ -> @div class: 'spacer'
+    spacer = $$ -> @div class: 'tool-bar-spacer'
     @toolbarView.append spacer
     spacer

--- a/styles/theme-atom-dark-ui.less
+++ b/styles/theme-atom-dark-ui.less
@@ -1,0 +1,16 @@
+.theme-atom-dark-ui {
+  .tool-bar-top {
+    border-left: 0 none;
+    border-top: 0 none;
+    border-right: 0 none;
+  }
+  .tool-bar-right {
+    border: 0 none;
+  }
+  .tool-bar-bottom {
+    border: 0 none;
+  }
+  .tool-bar-left {
+    border: 0 none;
+  }
+}

--- a/styles/theme-atom-light-ui.less
+++ b/styles/theme-atom-light-ui.less
@@ -1,0 +1,16 @@
+.theme-atom-light-ui {
+  .tool-bar-top {
+    border-left: 0 none;
+    border-top: 0 none;
+    border-right: 0 none;
+  }
+  .tool-bar-right {
+    border: 0 none;
+  }
+  .tool-bar-bottom {
+    border: 0 none;
+  }
+  .tool-bar-left {
+    border: 0 none;
+  }
+}

--- a/styles/theme-flatland-dark-ui.less
+++ b/styles/theme-flatland-dark-ui.less
@@ -1,0 +1,18 @@
+.theme-flatland-dark-ui {
+  .tool-bar-top {
+    border-left: 0 none;
+    border-top: 0 none;
+    border-right: 0 none;
+  }
+  .tool-bar-right {
+    border-bottom: 0 none;
+    border-top: 0 none;
+    border-right: 0 none;
+  }
+  .tool-bar-bottom {
+    border: 0 none;
+  }
+  .tool-bar-left {
+    border: 0 none;
+  }
+}

--- a/styles/theme-one-dark-ui.less
+++ b/styles/theme-one-dark-ui.less
@@ -1,0 +1,20 @@
+.theme-one-dark-ui {
+  .tool-bar-top {
+    border-top: 0 none;
+  }
+  .tool-bar-right {
+    border-bottom: 0 none;
+    border-right: 0 none;
+    border-top: 0 none;
+    margin-left: 8px;
+    margin-right: -8px;
+  }
+  .tool-bar-bottom {
+    border-top: 0 none;
+  }
+  .tool-bar-left {
+    border-bottom: 0 none;
+    border-left: 0 none;
+    border-top: 0 none;
+  }
+}

--- a/styles/theme-one-light-ui.less
+++ b/styles/theme-one-light-ui.less
@@ -1,0 +1,20 @@
+.theme-one-light-ui {
+  .tool-bar-top {
+    border-top: 0 none;
+  }
+  .tool-bar-right {
+    border-bottom: 0 none;
+    border-right: 0 none;
+    border-top: 0 none;
+    margin-left: 8px;
+    margin-right: -8px;
+  }
+  .tool-bar-bottom {
+    border-top: 0 none;
+  }
+  .tool-bar-left {
+    border-bottom: 0 none;
+    border-left: 0 none;
+    border-top: 0 none;
+  }
+}

--- a/styles/toolbar.less
+++ b/styles/toolbar.less
@@ -2,43 +2,51 @@
 @import "../iconsets/ionicons/ionicons";
 @import "../iconsets/font-awesome/font-awesome";
 
-#toolbar {
-  background-color: @app-background-color;
+.tool-bar {
+  @button-margin-size: 2px;
+  @button-border-size: 1px;
+  background-color: @base-background-color;
+  border: 1px solid @base-border-color;
   color: @text-color;
-  text-align: center;
 
-  &.top {
-
+  &.tool-bar-top {
+    border-top: 0 none;
   }
-  &.right {
-    border-right: 1px solid @base-border-color;
-    border-left: 1px solid @base-border-color;
+  &.tool-bar-right {
+    border-bottom: 0 none;
+    border-top: 0 none;
     margin-left: -1px;
   }
-  &.bottom {
-    
+  &.tool-bar-bottom {
+    margin-top: -1px;
   }
-  &.left {
-    border-right: 1px solid @base-border-color;
-  }
-
-  &.horizontal {
-    .spacer {
-      height: 100%;
-      border-right: 1px solid @overlay-border-color;
-    }
-  }
-  &.vertical {
-    .spacer {
-      width: 100%;
-      border-bottom: 1px solid @overlay-border-color;
-    }
+  &.tool-bar-left {
+    border-bottom: 0 none;
+    border-left: 0 none;
+    border-top: 0 none;
   }
 
-  .icon {
-    float: left;
+  .tool-bar-btn {
+    border: @button-border-size solid transparent;
+    border-radius: 3px;
+    color: @text-color;
     cursor: pointer;
+    display: block;
+    float: left;
+    line-height: 2em;
+    margin: @button-margin-size;
+    text-align: center;
+    text-shadow: none;
+    vertical-align: middle;
+
+    + .tool-bar-btn {
+      margin-left: 0;
+    }
+
     &:hover {
+      background-color: @button-background-color-hover;
+      background-image: linear-gradient(lighten(@button-background-color-hover, 2%), @button-background-color-hover);
+      border: @button-border-size solid @button-border-color;
       color: @text-color-highlight;
     }
     &:before {
@@ -50,61 +58,57 @@
     }
   }
 
-  .spacer {
+  &.tool-bar-horizontal .tool-bar-spacer {
+    border-left: @button-border-size solid @button-background-color;
+    border-right: @button-border-size solid @button-border-color;
+    display: block;
     float: left;
-    &:first-child {
-      display: none;
-    }
+    margin: @button-margin-size + 3 0;
+  }
+  &.tool-bar-vertical .tool-bar-spacer {
+    border-bottom: @button-border-size solid @button-background-color;
+    border-top: @button-border-size solid @button-border-color;
+    display: block;
+    float: left;
+    margin: 0 @button-margin-size + 3;
   }
 
-  &.icons16px {
-    .size(16px*2);
+  &.tool-bar-16px {
+    .tool-bar-size(16px * 2);
   }
-  &.icons24px {
-    .size(24px*2);
+  &.tool-bar-24px {
+    .tool-bar-size(24px * 2);
   }
-  &.icons32px {
-    .size(32px*2);
+  &.tool-bar-32px {
+    .tool-bar-size(32px * 2);
   }
 
-  .size(@size) {
+  .tool-bar-size(@size) {
     line-height: @size;
 
-    &.top {
+    &.tool-bar-horizontal {
+      height: @size + (@button-border-size * 3)+ (@button-margin-size * 2);
       width: 100%;
-      height: @size + 1;
     }
-    &.right {
-      width: @size + 1;
+    &.tool-bar-vertical {
       height: 100%;
-    }
-    &.bottom {
-      width: 100%;
-      height: @size + 1;
-    }
-    &.left {
-      width: @size + 1;
-      height: 100%;
+      width: @size + (@button-border-size * 3) + (@button-margin-size * 2);
     }
 
-    &.horizontal {
-      .icon {
-        width: @size;
-        height: 100%;
-      }
-    }
-    &.vertical {
-      .icon {
-        width: 100%;
-        height: @size;
-      }
-    }
-
-    .icon {
+    .tool-bar-btn {
+      height: @size + (@button-border-size * 2);
+      width: @size + (@button-border-size * 2);
       &:before {
         font-size: @size / 2;
         line-height: @size;
       }
+    }
+
+    &.tool-bar-horizontal .tool-bar-spacer {
+      height: @size - 4;
+    }
+    &.tool-bar-vertical .tool-bar-spacer {
+      width: @size - 4;
     }
   }
 }

--- a/styles/toolbar.less
+++ b/styles/toolbar.less
@@ -9,23 +9,6 @@
   border: 1px solid @base-border-color;
   color: @text-color;
 
-  &.tool-bar-top {
-    border-top: 0 none;
-  }
-  &.tool-bar-right {
-    border-bottom: 0 none;
-    border-top: 0 none;
-    margin-left: -1px;
-  }
-  &.tool-bar-bottom {
-    margin-top: -1px;
-  }
-  &.tool-bar-left {
-    border-bottom: 0 none;
-    border-left: 0 none;
-    border-top: 0 none;
-  }
-
   .tool-bar-btn {
     border: @button-border-size solid transparent;
     border-radius: 3px;

--- a/styles/toolbar.less
+++ b/styles/toolbar.less
@@ -39,10 +39,6 @@
     text-shadow: none;
     vertical-align: middle;
 
-    + .tool-bar-btn {
-      margin-left: 0;
-    }
-
     &:hover {
       background-color: @button-background-color-hover;
       background-image: linear-gradient(lighten(@button-background-color-hover, 2%), @button-background-color-hover);
@@ -56,6 +52,13 @@
     &.disabled {
       color: @text-color-subtle;
     }
+  }
+
+  &.tool-bar-horizontal .tool-bar-btn + .tool-bar-btn {
+    margin-left: 0;
+  }
+  &.tool-bar-vertical .tool-bar-btn + .tool-bar-btn {
+    margin-top: 0;
   }
 
   &.tool-bar-horizontal .tool-bar-spacer {


### PR DESCRIPTION
This PR contains improvements for a better design and layout of the toolbars. The design is now better integrated into the standard themes. I rewrote all classes to `tool-bar-*` to keep in sync with the [status-bar](https://github.com/atom/status-bar/blob/master/lib/status-bar-view.coffee#L7). And I also removed the ID's to make multiple toolbars possible in the future.

A picture is worth a thousand words:
![toolbar](https://cloud.githubusercontent.com/assets/55841/7237104/872300b6-e799-11e4-920d-03fd7cb14169.png)
![toolbar](https://cloud.githubusercontent.com/assets/55841/7237539/78150b2a-e79c-11e4-98ab-409f031a5567.png)
![toolbar](https://cloud.githubusercontent.com/assets/55841/7237168/0be98716-e79a-11e4-8b94-bfb09b9fedc5.png)

Closes #19

TODO:
* [x] Atom Dark
* [x] Atom Light
* [x] One Dark
* [x] One Light
* [x] [Flatland Dark UI Theme](https://atom.io/themes/flatland-dark-ui)
* [x] ~~Check more themes~~ -> _Moved theme specific code into their own stylesheets_
* [x] ~~Make `ToolbarView` an custom `HTMLElement` (e.g. like [status-bar](https://github.com/atom/status-bar/blob/master/lib/status-bar-view.coffee#L110)) (Optional)~~ -> _Another PR_

~~This is still work in progress (WIP), but~~ I love to hear what you think...