### PR TITLE
Add toolbar position to Atom menu & toolbar contextmenu

### DIFF
--- a/menus/toolbar.cson
+++ b/menus/toolbar.cson
@@ -1,13 +1,36 @@
-'menu': [
+menu: [
   {
-    'label': 'Packages'
-    'submenu': [
-      'label': 'Toolbar'
-      'submenu': [
-        { 'label': 'Toggle', 'command': 'toolbar:toggle' }
-      ]
+    label: 'Packages'
+    submenu: [
+      {
+        label: '&Toolbar'
+        submenu: [
+          { label: '&Toggle', command: 'toolbar:toggle' }
+          {
+            label: '&Position',
+            submenu: [
+              { label: 'Top', command: 'toolbar:position:top', type: 'radio' }
+              { label: 'Right', command: 'toolbar:position:right', type: 'radio' }
+              { label: 'Bottom', command: 'toolbar:position:bottom', type: 'radio' }
+              { label: 'Left', command: 'toolbar:position:left', type: 'radio' }
+            ]
+          }
+        ]
+      }
     ]
   }
 ],
-'context-menu':
-  'atom-workspace': []
+'context-menu': {
+  '.tool-bar': [
+    { label: '&Hide Toolbar', command: 'toolbar:toggle' }
+    {
+      label: '&Position',
+      submenu: [
+        { label: 'Top', command: 'toolbar:position:top' }
+        { label: 'Right', command: 'toolbar:position:right' }
+        { label: 'Bottom', command: 'toolbar:position:bottom' }
+        { label: 'Left', command: 'toolbar:position:left' }
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "atom-space-pen-views": "^2.0.3"
+    "atom-space-pen-views": "^2.0.3",
+    "underscore-plus": "^1.6.6"
   }
 }


### PR DESCRIPTION
This PR adds the toolbar position option to both Atom's main menu & toolbar contextmenu.

![atom_menu](https://cloud.githubusercontent.com/assets/55841/7340048/651eea76-ec84-11e4-9541-a93cd0834bb6.jpg)
![atom_contextmenu](https://cloud.githubusercontent.com/assets/55841/7340049/67a61c1a-ec84-11e4-91bc-664f0b2801df.png)

To make that possible, I added 4 more commands and fixed a bug where toolbar position was called to many times.

The main menu makes use of the undocumented radio-menu-items, which the contextmenu doesn't have ([yet](https://github.com/atom/atom/issues/6517)).